### PR TITLE
ci: auto-release example app APK on PR commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main, develop]
   pull_request:
 
+permissions:
+  contents: write
+
 jobs:
   typescript:
     name: TypeScript & Lint
@@ -83,6 +86,36 @@ jobs:
         working-directory: ./example/android
         run: ./gradlew :amehmeto-expo-list-installed-apps:testDebugUnitTest
 
-      - name: Build example Android app
+      - name: Build example Android app (release)
         working-directory: ./example/android
-        run: ./gradlew assembleDebug
+        run: ./gradlew assembleRelease
+
+      - name: Rename APK
+        run: |
+          mv example/android/app/build/outputs/apk/release/app-release.apk \
+             example/android/app/build/outputs/apk/release/expo-list-installed-apps.apk
+
+      - name: Upload APK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: expo-list-installed-apps
+          path: example/android/app/build/outputs/apk/release/expo-list-installed-apps.apk
+          retention-days: 30
+
+      - name: Create PR release
+        if: github.event_name == 'pull_request'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: pr-${{ github.event.pull_request.number }}-${{ github.sha }}
+          name: "List Installed Apps Example APK - PR #${{ github.event.pull_request.number }}"
+          body: |
+            Automated build of the **List Installed Apps** example app for PR #${{ github.event.pull_request.number }}.
+
+            **Commit:** ${{ github.sha }}
+            **Branch:** ${{ github.head_ref }}
+
+            Download the APK below to test the changes.
+          files: example/android/app/build/outputs/apk/release/expo-list-installed-apps.apk
+          prerelease: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Build release APK (bundles JS for standalone use)
- Upload APK as artifact and create GitHub pre-release
- Name APK as expo-list-installed-apps.apk

🤖 Generated with [Claude Code](https://claude.com/claude-code)