### PR TITLE
fix(android): return all launcher apps instead of only those with DEFAULT category

### DIFF
--- a/android/src/main/java/expo/modules/listinstalledapps/ExpoListInstalledAppsModule.kt
+++ b/android/src/main/java/expo/modules/listinstalledapps/ExpoListInstalledAppsModule.kt
@@ -161,12 +161,12 @@ class ExpoListInstalledAppsModule : Module() {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                     pkgAppsList = context.packageManager.queryIntentActivities(
                         Intent(Intent.ACTION_MAIN, null).addCategory(Intent.CATEGORY_LAUNCHER),
-                        PackageManager.ResolveInfoFlags.of(PackageManager.MATCH_DEFAULT_ONLY.toLong())
+                        PackageManager.ResolveInfoFlags.of(0L)
                     )
                 } else {
                     pkgAppsList = context.packageManager.queryIntentActivities(
                         Intent(Intent.ACTION_MAIN, null).addCategory(Intent.CATEGORY_LAUNCHER),
-                        PackageManager.GET_META_DATA
+                        0
                     )
                 }
 


### PR DESCRIPTION
## Summary
- Fixed `queryIntentActivities` to return all apps with launcher icons instead of only ~8 apps
- Removed `MATCH_DEFAULT_ONLY` flag which was filtering out apps that don't have `DEFAULT` category in their launcher intent-filter
- Most launcher activities only declare `LAUNCHER` category, not `DEFAULT`, causing the module to miss 50+ apps

## Test plan
- [ ] Build and run the example app on Android
- [ ] Verify the app list now shows all installed apps with launcher icons (50+ apps instead of 8-9)
- [ ] Test with both `user` and `system` type filters

🤖 Generated with [Claude Code](https://claude.com/claude-code)