### PR TITLE
chore: add lint check to pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,2 @@
+npm run lint -- --max-warnings 0
 npm test

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,6 +1,6 @@
-import { listInstalledApps } from './index'
-import ExpoListInstalledAppsModule from './ExpoListInstalledAppsModule'
 import { AppType } from './ExpoListInstalledApps.types'
+import ExpoListInstalledAppsModule from './ExpoListInstalledAppsModule'
+import { listInstalledApps } from './index'
 
 // Mock the native module
 jest.mock('./ExpoListInstalledAppsModule', () => ({


### PR DESCRIPTION
## Summary
- Add lint with `--max-warnings 0` to pre-commit hook to catch warnings before they reach GitHub
- Fix import order in test file

## Changes
- `.husky/pre-commit`: Run lint before tests
- `src/index.test.ts`: Correct import order per eslint rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)