### PR TITLE
fix(ci): skip pre-push hooks in CI environment

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,3 +1,8 @@
+# Skip pre-push hooks in CI (checks already run in CI workflow before semantic-release)
+if [ "$CI" = "true" ]; then
+  exit 0
+fi
+
 # Block direct push to main/master
 sh .husky/scripts/no-direct-push-main-master.sh
 


### PR DESCRIPTION
## Summary
- Skip pre-push hooks when running in CI environment
- The CI workflow already runs all checks (tests, linting, detekt) before semantic-release
- This prevents the pre-push hook from failing during semantic-release's git push

## Test plan
- [x] Pre-push hooks still run locally
- [ ] Semantic-release should now succeed on master

🤖 Generated with [Claude Code](https://claude.com/claude-code)