### PR TITLE
fix: remove semantic-release plugins that push to protected branch

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -3,18 +3,10 @@
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
-    "@semantic-release/changelog",
     [
       "@semantic-release/npm",
       {
         "npmPublish": false
-      }
-    ],
-    [
-      "@semantic-release/git",
-      {
-        "assets": ["package.json", "package-lock.json", "CHANGELOG.md"],
-        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
       }
     ],
     [


### PR DESCRIPTION
## Summary
- Remove `@semantic-release/git` and `@semantic-release/changelog` — they push commits directly to master, which is blocked by branch protection rules
- Matches the working setup in expo-foreground-service

## Root cause
Branch protection on master requires PRs and status checks. `@semantic-release/git` tries to push a release commit (package.json, CHANGELOG.md) directly, causing `GH006: Protected branch update failed`.

## Test plan
- [ ] CI passes on this PR
- [ ] After merge, Release workflow succeeds on master

🤖 Generated with [Claude Code](https://claude.com/claude-code)